### PR TITLE
Fixed MuiCheckBoxGroup value computation

### DIFF
--- a/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
+++ b/packages/vulcan-ui-material/lib/components/forms/base-controls/MuiCheckboxGroup.jsx
@@ -95,10 +95,10 @@ const MuiCheckboxGroup = createReactClass({
   },
   
   renderElement: function () {
-    const { name, options, disabled: _disabled } = this.props.inputProperties;
+    const { name, options, disabled: _disabled, value:_values } = this.props.inputProperties;
     const controls = options.map((checkbox, key) => {
-      let value = checkbox.value;
-      let checked = (value.indexOf(value) !== -1);
+      let checkboxValue = checkbox.value;
+      let checked = (_values.indexOf(checkboxValue) !== -1);
       let disabled = checkbox.disabled || _disabled;
       const Component = this.props.variant === 'switch' ? Switch : Checkbox;
       
@@ -107,10 +107,10 @@ const MuiCheckboxGroup = createReactClass({
           key={key}
           control={
             <Component
-              inputRef={(c) => this[name + '-' + value] = c}
+              inputRef={(c) => this[name + '-' + checkboxValue] = c}
               checked={checked}
               onChange={this.changeCheckbox}
-              value={value}
+              value={checkboxValue}
               disabled={disabled}
             />
           }


### PR DESCRIPTION
With the commit before, all the checkbox were selected from the beginning an couldn't be unselected. This is fixed